### PR TITLE
Ensure the config directory exists in all builds

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -256,6 +256,11 @@ bool game::opening_screen()
     dirent *dp;
     DIR *dir;
 
+    if (!assure_dir_exist(FILENAMES["config_dir"].c_str())) {
+        popup(_("Unable to make config directory. Check permissions."));
+        return false;
+    }
+    
     if (!assure_dir_exist(FILENAMES["savedir"])) {
         popup(_("Unable to make save directory. Check permissions."));
         return false;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -256,7 +256,7 @@ bool game::opening_screen()
     dirent *dp;
     DIR *dir;
 
-    if (!assure_dir_exist(FILENAMES["config_dir"].c_str())) {
+    if (!assure_dir_exist(FILENAMES["config_dir"])) {
         popup(_("Unable to make config directory. Check permissions."));
         return false;
     }
@@ -266,7 +266,7 @@ bool game::opening_screen()
         return false;
     }
 
-    if (!assure_dir_exist(FILENAMES["templatedir"].c_str())) {
+    if (!assure_dir_exist(FILENAMES["templatedir"])) {
         popup(_("Unable to make templates directory. Check permissions."));
         return false;
     }


### PR DESCRIPTION
On a linux curses build with no build flags, the config directory would not be created, leaving the user unable to save any changes to the default options. The assurance tests for this directory were only in the windows curses build and the tiles build code paths. This change always ensures it exists.